### PR TITLE
ramips: fix network setup for Ubiquiti ER-X/ER-X-SFP

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -48,10 +48,10 @@ ramips_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;
 	ubnt,edgerouter-x)
-		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4" "eth0"
+		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
 		;;
 	ubnt,edgerouter-x-sfp)
-		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
+		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 		;;
 	zyxel,wap6805)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"


### PR DESCRIPTION
The function name ucidef_set_interface_lan_wan does not exist,
use the proper name by adding an "s" and thereby fix network
setup on these devices.

Fixes: 22468cc40c8b (ramips: erx and erx-sfp: fix missing WAN interface)

Signed-off-by: Nelson Cai <niphor@gmail.com>
[commit message/title facelift]
Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
